### PR TITLE
README: once-over

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,8 @@ published to the [AppCenter Flatpak repository][1]. If any questions or
 requested changes come up during the review process, the reviewer will tag the
 app developer in the conversation on the pull request if possible.
 
-If your app was added with AppCenter Dashboard, future releases and tagged
-commits will be automatically submitted for review and approval as well. If you
-opened a pull request against this repository, you will need to open a new pull
-request for each release, or use the AppCenter Dashboard to set up automatic
-submission of releases.
+Once your app is approved and merged into this repository, future releases and
+tagged commits will be automatically submitted for review and approval.
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,39 @@
 # AppCenter Reviews
 
-This repository is used for deploying applications to the [elementary flatpak
-repository][1]. You can view your review status by [looking at the open PRs][2].
+This repository is used for deploying apps to the [elementary AppCenter Flatpak
+repository][1]. You can view your or any other app's review status by checking
+[open pull requests][2].
 
-To submit an application, please use the [AppCenter dashboard][3], as it will
-speed up the review process and ensure all the needed data is entered correctly.
-If you want to publish a git repository that is not on GitHub, make sure you
-adhere to the [publishing requirements][4], then you can make a PR here.
+>⚠️ **Note:** The new AppCenter Dashboard is unfinished and under rapid
+development. If you have issues using it, please [report them][3].
+
+To submit an app, please use [AppCenter Dashboard][4], as it will speed up the
+review process and ensure all the needed data is entered correctly. If you want
+to publish an app that is not hosted on GitHub, your has an RDNN that does not
+match where the code is hosted, or are having an issue submitting with AppCenter
+Dashboard: first make sure your app adheres to the [publishing requirements][5],
+then submit a pull request against this repository following the structure
+below.
 
 ## Review Process
 
-All applications currently in the review queue can be viewed in the
-[pending PRs][2]. Once the PR is approved and merged by one of our reviewers, it
-will be published to our [flatpak repository][1]. If any questions or changes
-come up during the review process, our reviewer will tag the application author
-in the conversation (if possible).
+All apps and updates in the review queue are listed as [open pull requests][2].
+Once a pull request is approved and merged by a reviewer, that app will be
+published to the [AppCenter Flatpak repository][1]. If any questions or
+requested changes come up during the review process, the reviewer will tag the
+app developer in the conversation on the pull request if possible.
 
-## Repo Structure
+If your app was added with AppCenter Dashboard, future releases and tagged
+commits will be automatically submitted for review and approval as well. If you
+opened a pull request against this repository, you will need to open a new pull
+request for each release, or use the AppCenter Dashboard to set up automatic
+submission of releases.
 
-All application releases in this repository are found under the `application/`
-folder and follow this schema `<rdnn>/<release tag>.json`. The JSON file looks
-like this:
+## Repository Structure
+
+All app releases in this repository are found under the `applications/` folder
+and follow this schema `<rdnn>/<release tag>.json`. The JSON file looks like
+this:
 
 ```json
 {
@@ -34,5 +47,6 @@ The `source` field needs to be a publicly accessible git repository. The
 
 [1]: https://flatpak.elementary.io
 [2]: https://github.com/elementary/appcenter-reviews/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc
-[3]: https://beta.developer.elementary.io
-[4]: https://docs.elementary.io/develop/appcenter/publishing-requirements
+[3]: https://github.com/elementary/appcenter-dashboard/issues
+[4]: https://beta.developer.elementary.io
+[5]: https://docs.elementary.io/develop/appcenter/publishing-requirements

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ this:
 }
 ```
 
-The `source` field needs to be a publicly accessible git repository. The
-`commit` field is the full git sha for the release we are building.
+The `source` field needs to be a publicly accessible Git repository. The
+`commit` field is the full Git sha for the release we are building.
 
 [1]: https://flatpak.elementary.io
 [2]: https://github.com/elementary/appcenter-reviews/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc


### PR DESCRIPTION
Tried to follow the [GitHub docs style guide](https://github.com/github/explore/blob/main/docs/styleguide.md) for terms as well as some easy consistency things like:
- Use "app" instead of "application"
- Capitalize Flatpak
- Refer to the repo as the "AppCenter Flatpak repository"
- Refer to the dashboard as "AppCenter Dashboard"

I also added a note and link to the AppCenter Dashboard repository for issues, and mentioned submitting a PR here if your RDNN doesn't match where the code is hosted.