### PR TITLE
Actions: clone full depth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Checkout
         run: |
-          git clone ${{ needs.parse.outputs.source }} --depth 1 .
+          git clone ${{ needs.parse.outputs.source }} .
           git checkout ${{ needs.parse.outputs.commit }}
 
       - name: Build

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Checkout
         run: |
-          git clone ${{ needs.parse.outputs.source }} --depth 1 .
+          git clone ${{ needs.parse.outputs.source }} .
           git checkout ${{ needs.parse.outputs.commit }}
 
       - name: Build


### PR DESCRIPTION
We can't assume the tag is the latest commit. Should fix the CI issue on #10.