### PR TITLE
Update com.github.avojak.iridium to 1.3.2

### DIFF
--- a/applications/com.github.avojak.iridium.json
+++ b/applications/com.github.avojak.iridium.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/iridium.git",
-  "commit": "f8a850c6805b8705ad28bd2be96a3a7d773220a8",
-  "version": "1.3.1"
+  "commit": "fe30d3c2bf7177fe72973be140206a9bb42218b3",
+  "version": "1.3.2"
 }


### PR DESCRIPTION
Fixing an issue where my Stripe public key was truncated (https://github.com/avojak/iridium/issues/164)