### PR TITLE
Action appcenter review find manifest update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Manifest
         id: manifest
-        uses: elementary/action-appcenter-review-find-manifest@v1.0.3
+        uses: elementary/action-appcenter-review-find-manifest@v1.2.0
         with:
           rdnn: ${{ needs.parse.outputs.rdnn }}
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Manifest
         id: manifest
-        uses: elementary/action-appcenter-review-find-manifest@v1.0.3
+        uses: elementary/action-appcenter-review-find-manifest@v1.2.0
         with:
           rdnn: ${{ needs.parse.outputs.rdnn }}
 


### PR DESCRIPTION
Update `elementary/action-appcenter-review-find-manifest` to latest version, allowing flatpak manifests to be in the `elementary/` or `flatpak/` folders.