### PR TITLE
Review Action: add a check for sandbox permissions

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,6 +30,7 @@ jobs:
             - [ ] AppData custom colors are contrasty
             - [ ] Name is unique and non-confusing
             - [ ] Uses elementary Flatpak runtime
+            - [ ] Sandbox permissions are reasonable
 
   parse:
     name: Parse


### PR DESCRIPTION
Something else we need to double check is if the app has sandbox permissions that seem unreasonable