### PR TITLE
Use rabbitbot token for checklist

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Checklist
         uses: elementary/action-appcenter-review-checklist@v1.0.0
         with:
+          token: ${{ github.secrets.GIT_USER_TOKEN }}
           body: |
             ## Review Checklist
 


### PR DESCRIPTION
This _should_ fix https://github.com/elementary/appcenter-reviews/issues/101 by using the rabbitbot token for the API request instead of the default token.