### PR TITLE
com.github.ztefn.haguichi 1.145.3

### DIFF
--- a/applications/com.github.ztefn.haguichi.json
+++ b/applications/com.github.ztefn.haguichi.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ztefn/haguichi.git",
-  "commit": "07e8ae3e1fa059b3cbc42067e14b825da99c58a4",
-  "version": "1.145.2"
+  "commit": "b55912bf6a759316055813863f49cf697f646a60",
+  "version": "1.145.3"
 }


### PR DESCRIPTION
Repository: [ztefn/haguichi](https://github.com/ztefn/haguichi)
Submitted By: @ztefn
Release Tag: [1.145.3](https://github.com/ztefn/haguichi/releases/tag/1.145.3)
Changed Code: [1.145.2...1.145.3](https://github.com/ztefn/haguichi/compare/1.145.2...1.145.3#diff-22391d6974c007b8c4f83f47f13c077c1c6a23c96941e780493be79a536bd42c)

This is a minor update that pins all GTK settings (stylesheet, icon theme, etc) so that if someone installs the flatpak from AppCenter on another distro everything looks as intended.