### PR TITLE
Create com.github.raibtoffoletto.litteris.json

### DIFF
--- a/applications/com.github.raibtoffoletto.litteris.json
+++ b/applications/com.github.raibtoffoletto.litteris.json
@@ -1,0 +1,6 @@
+
+{
+  "source": "https://github.com/raibtoffoletto/litteris.git",
+  "commit": "cb49875c2028a4a678f20373656935d7ecb65607",
+  "version": "0.1.9"
+}

--- a/applications/com.github.raibtoffoletto.litteris.json
+++ b/applications/com.github.raibtoffoletto.litteris.json
@@ -1,6 +1,6 @@
 
 {
   "source": "https://github.com/raibtoffoletto/litteris.git",
-  "commit": "cb49875c2028a4a678f20373656935d7ecb65607",
+  "commit": "b30fcaa1da250f02612297cf9adff35c10fa2ff7",
   "version": "0.1.9"
 }


### PR DESCRIPTION
This updates Litteris to work with Odin's new global color scheme preferences and necessary files to be packed as flatpak.

The `--filesystem=home:create` flag is necessary in the case the user wants to sync the database across devices, they can use a dropbox, nextcloud, or any other synchronised directory for that. The local version of the database is kept in the directory returned by `Environment.get_user_data_dir ()`.


<!-- appcenter-review-checklist -->

## Review Checklist

- [x] App opens
- [x] Does what it says

### AppData
- [x] Name is unique and non-confusing
- [x] Matches description
- [x] https://github.com/raibtoffoletto/litteris/issues/20
- [x] https://github.com/raibtoffoletto/litteris/issues/22
- [x] Launchable tag with matching ID
- [x] Release tag with matching version and YYYY-MM-DD date
- [x] Custom colors meet WCAG A contrast or greater
- [x] OARS info matches

### Flatpak
- [x] Uses elementary runtime
- [x] https://github.com/raibtoffoletto/litteris/issues/21