### PR TITLE
com.github.jmoerman.goforit

### DIFF
--- a/applications/com.github.jmoerman.go-for-it.json
+++ b/applications/com.github.jmoerman.go-for-it.json
@@ -1,5 +1,0 @@
-{
-  "source": "https://github.com/JMoerman/Go-For-It.git",
-  "commit": "f626f185bc58f08f9d73afb2865e7acc6f16f825",
-  "version": "1.9.3"
-}

--- a/applications/com.github.jmoerman.go-for-it.json
+++ b/applications/com.github.jmoerman.go-for-it.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/JMoerman/Go-For-It.git",
+  "commit": "f626f185bc58f08f9d73afb2865e7acc6f16f825",
+  "version": "1.9.3"
+}

--- a/applications/com.github.jmoerman.goforit.json
+++ b/applications/com.github.jmoerman.goforit.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/JMoerman/GoForIt.git",
+  "commit": "9300ee4a2478f1dc7262de62abf80eb546033d8b",
+  "version": "1.9.4"
+}


### PR DESCRIPTION
This is my submission for _GoForIt!_ (formerly _Go For It!_)

I have submitted this 6 days prior via https://beta.developer.elementary.io/submissions, but that didn't appear to do much. (And it currently is offline.) If that submission is being processed please close this PR.

Things of note: I created the https://github.com/JMoerman/GoForIt repository for the AppCenter packaging files. The code is still hosted on https://github.com/JMoerman/Go-For-It. The reasons for this are:

- _GoForIt!_ is gradually splitting into a Gnome(/more desktop agnostic) and a elementary OS version. The differences are currently relatively small but will grow with time. I prefer not to have a flatpak manifest with a generic App-ID name in the code branch. (I prefer to keep packaging files out of the code branch altogether.)
- _Go For It!_ has been renamed to _GoForIt!_ as appstream (for example `appstreamcli`) will discard `go`, `for` `it` from the search string (it will keep `it!`) as these are all common words. Searching for `Go For It` will thus not give any useful results in AppCenter. _GoForIt!_ can at least be found by searching for  `GoForIt`, so the new situation should be at least a little better. As the name has changed, users will not upgrade from elementary OS 5 to 6 without reinstalling 3rd party apps, and the old App-ID contained hyphens I also want to rename the App-ID to `com.github.jmoerman.goforit`.

If you have suggestions on how to handle these issues, I would be happy to hear them.