### PR TITLE
Use stable Docker containers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
     needs: parse
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:daily
+      image: ghcr.io/elementary/flatpak-platform/runtime:6
       options: --privileged
 
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,7 +66,7 @@ jobs:
     needs: parse
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:daily
+      image: ghcr.io/elementary/flatpak-platform/runtime:6
       options: --privileged
 
     steps:


### PR DESCRIPTION
Since the applications being built in this repo will be built against the stable runtimes, we should download the stable containers from the registry that already include this runtime.