### PR TITLE
Updating Outliner to 1.6.0

### DIFF
--- a/applications/com.github.phase1geo.outliner.json
+++ b/applications/com.github.phase1geo.outliner.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/phase1geo/Outliner.git",
-  "commit": "5b1a62d80fb39fb7a52e6b25f58809b84a830667",
-  "version": "1.5.1"
+  "commit": "a19e112b02cbf1f80d4bedd5402373d3d0f9ddb3",
+  "version": "1.6.0"
 }


### PR DESCRIPTION
Updating com.github.phase1geo.outliner to version 1.6.0