### PR TITLE
org.small_tech.comet 1.1.1

### DIFF
--- a/applications/org.small_tech.comet.json
+++ b/applications/org.small_tech.comet.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/small-tech/comet.git",
+  "commit": "2a75775c635da9e2a73f33d03d6926d0f3d43909",
+  "version": "1.0.0"
+}

--- a/applications/org.small_tech.comet.json
+++ b/applications/org.small_tech.comet.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/small-tech/comet.git",
-  "commit": "eab51817876cfa38a5295f92b4afd6f1aea9d31d",
-  "version": "1.0.0"
+  "commit": "3a38ecb25e54e060f98db226907d8048b6cef9dd",
+  "version": "1.1.0"
 }

--- a/applications/org.small_tech.comet.json
+++ b/applications/org.small_tech.comet.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/small-tech/comet.git",
-  "commit": "3a38ecb25e54e060f98db226907d8048b6cef9dd",
-  "version": "1.1.0"
+  "commit": "fdb8f07080b72e6b75e487ec5f24cb564fd3cfed",
+  "version": "1.1.1"
 }

--- a/applications/org.small_tech.comet.json
+++ b/applications/org.small_tech.comet.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/small-tech/comet.git",
-  "commit": "2a75775c635da9e2a73f33d03d6926d0f3d43909",
+  "commit": "e3a609ae23ca5356b9bb9c666508a90e600302ec",
   "version": "1.0.0"
 }

--- a/applications/org.small_tech.comet.json
+++ b/applications/org.small_tech.comet.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/small-tech/comet.git",
-  "commit": "e3a609ae23ca5356b9bb9c666508a90e600302ec",
+  "commit": "eab51817876cfa38a5295f92b4afd6f1aea9d31d",
   "version": "1.0.0"
 }


### PR DESCRIPTION
Request to add Comet to the elementary OS AppCenter.

https://github.com/small-tech/comet

  - __Update:__ Version 1.1.0. No longer requires Flatpak filesystem permissions.
  - __Update:__ Version 1.1.1. Fix: add releases section to Flatpak metadata.

<!-- appcenter-review-checklist -->

## Review Checklist

- [x] App opens
- [x] Does what it says
- [x] Categories match

### AppData
- [x] Name is unique and non-confusing
- [x] Matches description
- [x] Matches screenshot
- [x] Launchable tag with matching ID
- [x] Release tag with matching version and YYYY-MM-DD date
- [x] Custom colors meet WCAG A contrast or greater
- [x] OARS info matches

### Flatpak
- [x] Uses elementary runtime
- [x] Sandbox permissions are reasonable