### PR TITLE
com.github.avojak.iridium 1.6.1

### DIFF
--- a/applications/com.github.avojak.iridium.json
+++ b/applications/com.github.avojak.iridium.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/iridium.git",
-  "commit": "d2146cfed4a1e32a2311d3e2ab69fc0a6a53bdc8",
-  "version": "1.6.0"
+  "commit": "6dd49583a001174c8cf902c7251931d010679040",
+  "version": "1.6.1"
 }


### PR DESCRIPTION
Tiny translations update for Iridium: https://github.com/avojak/iridium/releases/tag/1.6.1