### PR TITLE
com.github.tenderowl.frog 0.2.1

### DIFF
--- a/applications/com.github.tenderowl.frog.json
+++ b/applications/com.github.tenderowl.frog.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/TenderOwl/Frog.git",
-  "commit": "06346c027eb9dffed5866d0157c34525261708de",
-  "version": "0.1.7"
+  "commit": "24a7672ba0f27f6b3bf28788c4b9435c88ef5fda",
+  "version": "0.2.0"
 }

--- a/applications/com.github.tenderowl.frog.json
+++ b/applications/com.github.tenderowl.frog.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/TenderOwl/Frog.git",
-  "commit": "24a7672ba0f27f6b3bf28788c4b9435c88ef5fda",
-  "version": "0.2.0"
+  "commit": "f9255fcbb5d792512c4996128741b3bd13295a5b",
+  "version": "0.2.1"
 }


### PR DESCRIPTION
Repo: [tenderowl/frog](/tenderowl/frog)
Submitted by @amka 

## What's Changed
* Command-line option `-e` allows to extract text and instantly copy it to the clipboard @FilePhil #26 
* Language configuration list now sorted alphabetically #25
* Fix Copy to clipboard button
* Update runtime to 6.1

**Full Changelog**: https://github.com/TenderOwl/Frog/compare/0.2.0...0.2.1