### PR TITLE
org.small_tech.comet 1.1.2

### DIFF
--- a/applications/org.small_tech.comet.json
+++ b/applications/org.small_tech.comet.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/small-tech/comet.git",
-  "commit": "fdb8f07080b72e6b75e487ec5f24cb564fd3cfed",
-  "version": "1.1.1"
+  "commit": "5df0e03200984ff073685c54e5edd48e0349f5ad",
+  "version": "1.1.2"
 }


### PR DESCRIPTION
 - Adds correct Stripe API key for AppCenter.

After [all that](https://github.com/elementary/appcenter-reviews/pull/225#issuecomment-990876055), I _still_ managed to add the wrong Stripe API key for AppCenter.  🤷

This update fixes that and should stop payments on AppCenter from failing for Comet. 🤓️👍️

## Changes since last release

https://github.com/small-tech/comet/compare/1.1.1...1.1.2

## Key change (no pun intended)

[data/comet.appdata.xml.in, line 32](https://github.com/small-tech/comet/compare/1.1.1...1.1.2#diff-4b3903819fa02b93057c2364c9af685fb93fc5d670d0a22f730cdd47d87030d7L32)

## To document: 

  - Do __not__ use the key that’s displayed in your Stripe account.
  - __DO__ use the key you get from https://beta.developer.elementary.io/submissions/add
  - To make things more confusing the first 26 letters of the keys, in my case at least, were the same, leading me to think that the key displayed on the Stripe account _was_ the right key.