### PR TITLE
com.github.avojak.iridium 1.8.0

### DIFF
--- a/applications/com.github.avojak.iridium.json
+++ b/applications/com.github.avojak.iridium.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/iridium.git",
-  "commit": "abdfcfce94cf3a4e05bd3c5575a071cf99aee044",
-  "version": "1.7.0"
+  "commit": "80960c5c221303c6daf9f12b06cb06f8aa67e5e0",
+  "version": "1.8.0"
 }


### PR DESCRIPTION
1.8.0 release of Iridium: https://github.com/avojak/iridium/releases/tag/1.8.0