### PR TITLE
Spice-Up 1.9.1 hotfix

### DIFF
--- a/applications/com.github.philip_scott.spice-up.json
+++ b/applications/com.github.philip_scott.spice-up.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/Philip-Scott/Spice-up.git",
-  "commit": "bccb474dd1e01db9b6f537e4277356a5884dc782",
-  "version": "1.9.0"
+  "commit": "6186bcd06bc6a77b6d06f11358877b9798ae59a4",
+  "version": "1.9.1"
 }


### PR DESCRIPTION
Updates the Spice-Up manifest for a hotfix release due to the SlideList slides expanding when not expected. OARS change comes bundled in as well :) 

**Full Changelog**: https://github.com/Philip-Scott/Spice-up/compare/1.9.0...1.9.1

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] Custom colors meet WCAG A contrast or greater
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable
