### PR TITLE
Update com.github.avojak.paint-spill to 1.1.0

### DIFF
--- a/applications/com.github.avojak.paint-spill.json
+++ b/applications/com.github.avojak.paint-spill.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/paint-spill.git",
-  "commit": "f9a7619b6fee19d426fa3a60c4e0c701258d95a5",
-  "version": "1.0.2"
+  "commit": "b39a770282c71c86d3cfbe4ecea6190fea288203",
+  "version": "1.1.0"
 }


### PR DESCRIPTION
Paint Spill 1.1.0 release: https://github.com/avojak/paint-spill/releases/tag/1.1.0