### PR TITLE
Update com.github.avojak.warble to 1.4.0

### DIFF
--- a/applications/com.github.avojak.warble.json
+++ b/applications/com.github.avojak.warble.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/warble.git",
-  "commit": "424c77843913aad0fe26760947bbaf62527bafa6",
-  "version": "1.3.1"
+  "commit": "40860dcc51993908745282d891942422bd1655ba",
+  "version": "1.4.0"
 }


### PR DESCRIPTION
Updating Warble with elementary OS 7 runtime: https://github.com/avojak/warble/releases/tag/1.4.0