### PR TITLE
com.github.avojak.paint-spill 1.2.0

### DIFF
--- a/applications/com.github.avojak.paint-spill.json
+++ b/applications/com.github.avojak.paint-spill.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/paint-spill.git",
-  "commit": "b39a770282c71c86d3cfbe4ecea6190fea288203",
-  "version": "1.1.0"
+  "commit": "a0088dc5578fa2c495c5efc26e7fab219f110a0f",
+  "version": "1.2.0"
 }


### PR DESCRIPTION
Updating Paint Spill with elementary OS 7 runtime: https://github.com/avojak/paint-spill/releases/tag/1.2.0