### PR TITLE
com.github.avojak.iridium 1.9.0

### DIFF
--- a/applications/com.github.avojak.iridium.json
+++ b/applications/com.github.avojak.iridium.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/iridium.git",
-  "commit": "08fcff030c327e1a87ce59b0812854aa79d958ff",
-  "version": "1.8.1"
+  "commit": "edf293bd5f8dc9642671b588ba267f05f35eaa51",
+  "version": "1.9.0"
 }


### PR DESCRIPTION
Updating Iridium with elementary OS 7 runtime: https://github.com/avojak/iridium/releases/tag/1.9.0