### PR TITLE
com.github.bluesabre.darkbar 1.0.1

### DIFF
--- a/applications/com.github.bluesabre.darkbar.json
+++ b/applications/com.github.bluesabre.darkbar.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/bluesabre/darkbar.git",
-  "commit": "0d045a9c8bb65d4fadea5febc8dcdac3d7b93f70",
-  "version": "0.1.2"
+  "commit": "919c0100da69de66a4cde077f3444b5387f20a66",
+  "version": "1.0.0"
 }

--- a/applications/com.github.bluesabre.darkbar.json
+++ b/applications/com.github.bluesabre.darkbar.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/bluesabre/darkbar.git",
-  "commit": "292865d09a7b5bc1c33699deacd098b76e8be3c5",
+  "commit": "304b282bf50565badab0ac152f3ae66665e97840",
   "version": "1.0.1"
 }

--- a/applications/com.github.bluesabre.darkbar.json
+++ b/applications/com.github.bluesabre.darkbar.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/bluesabre/darkbar.git",
-  "commit": "b1d2ac4d232848b125fe5a6f62e917a1c67542bf",
+  "commit": "292865d09a7b5bc1c33699deacd098b76e8be3c5",
   "version": "1.0.1"
 }

--- a/applications/com.github.bluesabre.darkbar.json
+++ b/applications/com.github.bluesabre.darkbar.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/bluesabre/darkbar.git",
-  "commit": "919c0100da69de66a4cde077f3444b5387f20a66",
-  "version": "1.0.0"
+  "commit": "b1d2ac4d232848b125fe5a6f62e917a1c67542bf",
+  "version": "1.0.1"
 }


### PR DESCRIPTION
https://github.com/bluesabre/darkbar/releases/tag/1.0.1

- AppStream: Add GNOME and elementary screenshots
- Flatpak: Add release details
- Flatpak: Force app to run via X11
- Flatpak: Reduce required permissions
- Flatpak: Switch to using sandboxed/packaged xprop
- Updated Translations: it, pl, tr

https://github.com/bluesabre/darkbar/releases/tag/1.0.0

- Appearance: Respect window controls layout
- Appearance: Support FreeDesktop dark style preference
- AppStream: Update x-appcenter-stripe
- Flatpak: Improved app identification and icon support
- Flatpak: Switch to io.elementary.Platform/Sdk 7
- Ignored Apps: Chrome/Edge PWA windows (always drawn by app)
- Ignored Apps: io.elementary.* (elementary always uses CSD)
- Ignored Apps: Zoom join windows (always unique)
- Meson: Fix shebang on meson/post_install.py
- Meson: Improve build system
- Preferences: Add new default style preference
- Wayland: Add support for XWayland windows
- X11: Avoid windows with null app_id
- X11: Reload window list if newly created window has no class name
- Updated Translations: es, fr, it, ja, lt, ms, ms@Arab, nl, pl, pt, pt_BR, pt_PT, ru, sv, zh, zh_CN