### PR TITLE
Bump Comic Sticks to version 1.5.3.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "a25f8d1295ebce67e987fd4e81f16cc4f055ca26",
-  "version": "1.5.2"
+  "commit": "6946e988487e7a00e1b59ed9db4b47de2e0ca93f",
+  "version": "1.5.3"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/1.5.3

## Review Checklist
  
  - [ ] App opens
  - [ ] Does what it says
  - [ ] Categories match
  
  ### AppData
  - [ ] Name is unique and non-confusing
  - [ ] Matches description
  - [ ] Matches screenshot
  - [ ] Launchable tag with matching ID
  - [ ] Release tag with matching version and YYYY-MM-DD date
  - [ ] Custom colors meet WCAG A contrast or greater
  - [ ] OARS info matches
  
  ### Flatpak
  - [ ] Uses elementary runtime
  - [ ] Sandbox permissions are reasonable