### PR TITLE
Update Comic Sticks to version 1.6.0.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "6946e988487e7a00e1b59ed9db4b47de2e0ca93f",
-  "version": "1.5.3"
+  "commit": "878bcad970be0742d0d1e94ed41234b2426f8c1e",
+  "version": "1.6.0"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/1.6.0
