### PR TITLE
Update Comic Sticks to 1.6.1.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "878bcad970be0742d0d1e94ed41234b2426f8c1e",
-  "version": "1.6.0"
+  "commit": "c007348b5cd2aac9cc82ffa35c5e3bbfecc01ca1",
+  "version": "1.6.1"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/1.6.1

## Review Checklist
  
  - [ ] App opens
  - [ ] Does what it says
  - [ ] Categories match
  
  ### AppData
  - [ ] Name is unique and non-confusing
  - [ ] Matches description
  - [ ] Matches screenshot
  - [ ] Launchable tag with matching ID
  - [ ] Release tag with matching version and YYYY-MM-DD date
  - [ ] Custom colors meet WCAG A contrast or greater
  - [ ] OARS info matches
  
  ### Flatpak
  - [ ] Uses elementary runtime
  - [ ] Sandbox permissions are reasonable