### PR TITLE
Update Comic Sticks to 1.6.2.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "c007348b5cd2aac9cc82ffa35c5e3bbfecc01ca1",
-  "version": "1.6.1"
+  "commit": "657d449db2bd78ddd3376561c1b03d5cbcd1aedc",
+  "version": "1.6.2"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/1.6.2