### PR TITLE
Update Comic Sticks to version 1.6.3.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "657d449db2bd78ddd3376561c1b03d5cbcd1aedc",
-  "version": "1.6.2"
+  "commit": "fab636cf14169dbc2fbadf566de595ae4dce2d39",
+  "version": "1.6.3"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/1.6.3