### PR TITLE
Update Comic Sticks to version 1.6.4.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "fab636cf14169dbc2fbadf566de595ae4dce2d39",
-  "version": "1.6.3"
+  "commit": "0dd7a32ba377af153fbf4b3882a6e4d8c18531c9",
+  "version": "1.6.4"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/1.6.4