### PR TITLE
Update Comic Sticks to 1.6.5.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "0dd7a32ba377af153fbf4b3882a6e4d8c18531c9",
-  "version": "1.6.4"
+  "commit": "6c816bae8a66807e5abbdda2212dd93ec5e60517",
+  "version": "1.6.5"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/1.6.5