### PR TITLE
com.github.ryonakano.atlas 1.0.1

### DIFF
--- a/applications/com.github.ryonakano.atlas.json
+++ b/applications/com.github.ryonakano.atlas.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ryonakano/atlas.git",
-  "commit": "1fe825fc6ddfb66e8e1da22c777f82de0e8c9958",
-  "version": "1.0.0"
+  "commit": "a5c2249ed1780a1036a53a58f334a76c77fb77bd",
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Just a couple of updates like translations and the dependency.

I know now it is recommended to use the version 7 of elementary Flatpak runtime, but if we try to perform that change, I also need to migrate to GTK 4 and libshumate at the same time, which is challenging for me. This is because the GNOME Flatpak runtime 42, which elementary Flatpak runtime depends on, removes the necessary dependencies. So I publish a release with 6.1 version of the runtime meanwhile.

See https://github.com/ryonakano/atlas/issues/26 for more details.