### PR TITLE
Update com.github.avojak.warble to 2.0.0

### DIFF
--- a/applications/com.github.avojak.warble.json
+++ b/applications/com.github.avojak.warble.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/avojak/warble.git",
-  "commit": "b69af4a9ea821f71fb2a3e5985bcd7a15f4ff18c",
-  "version": "1.5.0"
+  "commit": "982b1c8451ac46ffeb8dff4cb637b41f72da3905",
+  "version": "2.0.0"
 }


### PR DESCRIPTION
2.0.0 release of Warble: https://github.com/avojak/warble/compare/1.5.0...2.0.0