### PR TITLE
Update com.github.childishgiant.mixer to 1.1.0

### DIFF
--- a/applications/com.github.childishgiant.mixer.json
+++ b/applications/com.github.childishgiant.mixer.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ChildishGiant/mixer.git",
-  "commit": "1917193d2b18ca23d5920929d8b0124f38f3cb5d",
-  "version": "1.0.0"
+  "commit": "d706bae339223d76bec8f2ce5478540855db69d4",
+  "version": "1.1.0"
 }


### PR DESCRIPTION
This release adds 2 translations and fixes a flatpak permissions issue on some distros.  
https://github.com/ChildishGiant/mixer/releases/tag/1.1.0