### PR TITLE
Update com.github.ztefn.haguichi to 1.146.0

### DIFF
--- a/applications/com.github.ztefn.haguichi.json
+++ b/applications/com.github.ztefn.haguichi.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ztefn/haguichi.git",
-  "commit": "b55912bf6a759316055813863f49cf697f646a60",
-  "version": "1.145.3"
+  "commit": "34822b7a3324bf6934d54722c59040133d375806",
+  "version": "1.146.0"
 }


### PR DESCRIPTION
Rebased [elementary](https://github.com/ztefn/haguichi/tree/elementary) branch on top of master, from commit [0d4b58a to 6e6f411](https://github.com/ztefn/haguichi/compare/0d4b58a...6e6f411). Runtime updated to 7.1. Much spiderweb removed (in reference to obnoxious "Outdated" label in AppCenter).

Release tag: [1.146.0](https://github.com/ztefn/haguichi/releases/tag/1.146.0) (are tags still needed actually when now commit hashes are used in the json file?)