### PR TITLE
Bump Comic Sticks to version 1.7.1.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "6c816bae8a66807e5abbdda2212dd93ec5e60517",
-  "version": "1.6.5"
+  "commit": "df75f29c40996cd0f94173098db33db3454281bd",
+  "version": "v1.7.1"
 }


### PR DESCRIPTION
 Release notes for v1.7.0: https://github.com/rkoesters/xkcd-gtk/releases/tag/v1.7.0

Release notes for v1.7.1: https://github.com/rkoesters/xkcd-gtk/releases/tag/v1.7.1

## Review Checklist
  
  - [ ] App opens
  - [ ] Does what it says
  - [ ] Categories match
  
  ### AppData
  - [ ] Name is unique and non-confusing
  - [ ] Matches description
  - [ ] Matches screenshot
  - [ ] Launchable tag with matching ID
  - [ ] Release tag with matching version and YYYY-MM-DD date
  - [ ] Custom colors meet WCAG A contrast or greater
  - [ ] OARS info matches
  
  ### Flatpak
  - [ ] Uses elementary runtime
  - [ ] Sandbox permissions are reasonable