### PR TITLE
Revert "Bump flatpak/flatpak-github-actions from 5 to 6"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
           platforms: arm64
 
       - name: Build
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v5
         with:
           bundle: ${{ needs.parse.outputs.rdnn }}.flatpak
           manifest-path: ${{ steps.manifest.outputs.manifest }}
@@ -80,7 +80,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Deploy
-        uses: flatpak/flatpak-github-actions/flat-manager@v6
+        uses: flatpak/flatpak-github-actions/flat-manager@v5
         with:
           repository: appcenter
           flat-manager-url: https://flatpak-api.elementary.io

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -96,7 +96,7 @@ jobs:
           platforms: arm64
 
       - name: Build
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v5
         with:
           bundle: ${{ needs.parse.outputs.rdnn }}.flatpak
           manifest-path: ${{ steps.manifest.outputs.manifest }}


### PR DESCRIPTION
Reverts elementary/appcenter-reviews#442

Just in case we merge any more releases before this action gets fixed.

See https://github.com/flatpak/flatpak-github-actions/pull/131