### PR TITLE
com.github.ryonakano.louper 2.0.2

### DIFF
--- a/applications/com.github.ryonakano.louper.json
+++ b/applications/com.github.ryonakano.louper.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ryonakano/louper.git",
-  "commit": "8cec97a235588a91bb17e59c1de66462b30215f8",
-  "version": "2.0.1"
+  "commit": "fd51948dacfc52f588e1e0f08ca361a5624fa3e1",
+  "version": "2.0.2"
 }


### PR DESCRIPTION
- Diff from the previous release: https://github.com/ryonakano/louper/compare/2.0.1...2.0.2
- Release note: https://github.com/ryonakano/louper/releases/tag/2.0.2