### PR TITLE
com.github.cassidyjames.clairvoyant: 2.0.1 and EOL

### DIFF
--- a/applications/com.github.cassidyjames.clairvoyant.json
+++ b/applications/com.github.cassidyjames.clairvoyant.json
@@ -1,6 +1,6 @@
 {
   "source": "https://github.com/cassidyjames/clairvoyant.git",
-  "commit": "527c6f16abf03aba6599a383df5ba50174e2f7ff",
-  "version": "2.0.0",
-  "end-of-life": "The app is no longer maintained on AppCenter; new releases are available on Flathub"
+  "commit": "1ac1077bcb6ab5c00f9893045d4feceeb42bab41",
+  "version": "2.0.1",
+  "end-of-life": "The app is no longer maintained on elementary AppCenter; new releases are available on Flathub"
 }

--- a/applications/com.github.cassidyjames.clairvoyant.json
+++ b/applications/com.github.cassidyjames.clairvoyant.json
@@ -1,5 +1,6 @@
 {
   "source": "https://github.com/cassidyjames/clairvoyant.git",
   "commit": "527c6f16abf03aba6599a383df5ba50174e2f7ff",
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "end-of-life": "The app is no longer maintained on AppCenter; new releases are available on Flathub"
 }


### PR DESCRIPTION
Clairvoyant is no longer actively maintained for elementary AppCenter, but this PR bumps it to a new patch release which:

- Always uses the elementary stylesheet and icons
- Adds captions to screenshots in AppCenter
- Adds brand colors to AppCenter listing
- Fixes screenshot URLs
- Updates to the latest elementary Platform

The app UI and thus screenshots did not change.

Since it's not actively maintained (and newer versions contain a new design and new content that's not reflected here), I've marked it as EOL. I'm not sure if AppCenter does anything with that information, but it seems technically correct. 🤷🏻 

Changes: https://github.com/cassidyjames/clairvoyant/compare/2.0.0...2.0.1

<!-- appcenter-review-checklist -->

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] Custom colors meet WCAG A contrast or greater
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable