### PR TITLE
Update Comic Sticks to version 1.7.2.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "df75f29c40996cd0f94173098db33db3454281bd",
-  "version": "v1.7.1"
+  "commit": "8aa7c28e13c0383ebf6b9d4b28d501cdc47f3e34",
+  "version": "v1.7.2"
 }


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/v1.7.2

<!-- appcenter-review-checklist -->

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] Custom colors meet WCAG A contrast or greater
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable