### PR TITLE
Update com.github.ztefn.haguichi to 1.146.1

### DIFF
--- a/applications/com.github.ztefn.haguichi.json
+++ b/applications/com.github.ztefn.haguichi.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ztefn/haguichi.git",
-  "commit": "34822b7a3324bf6934d54722c59040133d375806",
-  "version": "1.146.0"
+  "commit": "fcc63a46b4f7fd75fa8fe91068cb55d2846ccfca",
+  "version": "1.146.1"
 }


### PR DESCRIPTION
Rebased [elementary](https://github.com/ztefn/haguichi/tree/elementary) branch on top of master, from commit [6e6f411 to d46f457](https://github.com/ztefn/haguichi/compare/6e6f411...d46f457). Runtime updated to 7.2.

Release tag: [1.146.1](https://github.com/ztefn/haguichi/releases/tag/1.146.1)