### PR TITLE
Create io.github.leolost2605.extension-manager.json

### DIFF
--- a/applications/io.github.leolost2605.extension-manager.json
+++ b/applications/io.github.leolost2605.extension-manager.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/leolost2605/Extension-Manager.git",
+  "commit": "dafb5026989cd9ea6829b249a4ca79881706436f",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
This is a little flatpak app I put together that easily allows you to manage extensions for gala, wingpanel and switchboard. It basically works by telling the user to add a [curated PPA](https://launchpad.net/~leolost/+archive/ubuntu/extensions) and then using package kit and a list of known extensions with some extra information to show the user a list of extensions they can install and uninstall.

Ok so I know this might get rejected because it violates quite a lot of publishing requirements (first and foremost by basically being an appstore and adding and removing software) however I think as it doesn't compete with AppCenter it might still be worth considering. Since many elementary apps like wingpanel, settings, gala, files, etc. have plugin systems built in I think there is a potential for a lot of extensions that can't be shipped natively because they go against design but are still very useful (e.g. [lenemter/wingpanel-indicator-namarupa](https://github.com/lenemter/wingpanel-indicator-namarupa)). IMO this currently is most hindered by not being able to easily find and install such extensions but instead having to look across github repos, add many ppas, or download debs etc.

So I'll take my chances on this one, let me know if there is the possibility of this getting accepted :)
Oh and btw if that's something that would be preferred I'm open to making it official however as I don't know how long this app will work (looking at immutable file systems coming) I'm not sure whether officially commiting to it is the right move 🤷