### PR TITLE
com.github.ryonakano.pinit 2.1.1

### DIFF
--- a/applications/com.github.ryonakano.pinit.json
+++ b/applications/com.github.ryonakano.pinit.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ryonakano/pinit.git",
-  "commit": "cac456d6a0240997251f795a4b60dd5169fe72d7",
-  "version": "1.4.1"
+  "commit": "30c8fa69629303f5bf69980bae7d39a8901f8fcf",
+  "version": "2.1.1"
 }


### PR DESCRIPTION
Publishing to AppCenter again thanks to `Granite.init ()`, which can force elementary stylesheet instead of Adwaita one.

- Diff from the previous release: https://github.com/ryonakano/pinit/compare/1.4.1..2.1.1
- Release note: https://github.com/ryonakano/pinit/releases/tag/2.1.1

<!-- appcenter-review-checklist -->

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] Custom colors meet WCAG A contrast or greater
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable