### PR TITLE
Bump flat-manager from v6.3 to 0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Deploy
-        uses: flatpak/flatpak-github-actions/flat-manager@v6.3
+        uses: flatpak/flatpak-github-actions/flat-manager@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf # v6.3 plus https://github.com/flatpak/flatpak-github-actions/pull/160
         with:
           repository: appcenter
           flat-manager-url: https://flatpak-api.elementary.io


### PR DESCRIPTION
v6.3 release plus https://github.com/flatpak/flatpak-github-actions/pull/160