### PR TITLE
Checklist: remove contrast check

### DIFF
--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -36,7 +36,6 @@
                 - [ ] Matches screenshot
                 - [ ] Launchable tag with matching ID
                 - [ ] Release tag with matching version and YYYY-MM-DD date
-                - [ ] Custom colors meet WCAG A contrast or greater
                 - [ ] OARS info matches
                 
                 ### Flatpak


### PR DESCRIPTION
These days appcenter generates the text color automatically so we don't need to check that brand colors are contrasty