### PR TITLE
workflows: switch to platform 8.0 container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
        fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7.1-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:8-${{ matrix.arch }}
       options: --privileged
 
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7.1-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:8-${{ matrix.arch }}
       options: --privileged
 
     steps:


### PR DESCRIPTION
Most application submissions should now be using this version of the runtime, so we can speed up builds a bit if we use the correct container version in the actions.