### PR TITLE
Update com.github.ztefn.haguichi to 1.151.0

### DIFF
--- a/applications/com.github.ztefn.haguichi.json
+++ b/applications/com.github.ztefn.haguichi.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ztefn/haguichi.git",
-  "commit": "fcc63a46b4f7fd75fa8fe91068cb55d2846ccfca",
-  "version": "1.146.1"
+  "commit": "bd9f09346fa97d2d6742251757bddb0afa2c1db0",
+  "version": "1.151.0"
 }


### PR DESCRIPTION
Rebased [elementary](https://github.com/ztefn/haguichi/tree/elementary) branch on top of master, from commit [d46f457 to c92a6f8](https://github.com/ztefn/haguichi/compare/d46f457...c92a6f8
).

Release tag: [1.151.0](https://github.com/ztefn/haguichi/releases/tag/1.151.0)

The user interface has been completely rebuild utilizing GTK4 and libadwaita. Plus the user interface is now largely constructed using [Gtk.Builder](https://docs.gtk.org/gtk4/class.Builder.html#gtkbuilder-ui-definitions) UI definitions instead of code.

This release also implements [Xdp.Portal](https://libportal.org/class.Portal.html) to request permission to run in the background.

In order to finally create this release for elementary OS i had to work my way around a bunch of issues in relation with support for GTK4 and libadwaita. I've done my best to report them all:
- elementary/stylesheet/issues/1310
- elementary/stylesheet/issues/1311
- elementary/stylesheet/issues/1312
- elementary/stylesheet/issues/1313
- elementary/stylesheet/issues/1314
- elementary/granite/issues/742

<div align="center">
<img src="/ztefn/haguichi/blob/bd9f09346fa97d2d6742251757bddb0afa2c1db0/data/screenshots/1.png?raw=true" width="594" />
</div>

<!-- appcenter-review-checklist -->

## Review Checklist

- [x] App opens
- [x] Does what it says
- [x] Categories match

### AppData
- [x] Name is unique and non-confusing
- [x] Matches description
- [x] Matches screenshot
- [x] Launchable tag with matching ID
- [x] Release tag with matching version and YYYY-MM-DD date
- [x] OARS info matches

### Flatpak
- [x] Uses elementary runtime
- [x] Sandbox permissions are reasonable