### PR TITLE
Actions: also update builder to 6.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
           platforms: arm64
 
       - name: Build
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.4
         with:
           bundle: ${{ needs.parse.outputs.rdnn }}.flatpak
           manifest-path: ${{ steps.manifest.outputs.manifest }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -68,7 +68,7 @@ jobs:
           platforms: arm64
 
       - name: Build
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.4
         with:
           bundle: ${{ needs.parse.outputs.rdnn }}.flatpak
           manifest-path: ${{ steps.manifest.outputs.manifest }}


### PR DESCRIPTION
Publish action is still failing. Looks like 6.4 is available for the builder as well as manager 