### PR TITLE
Update io.github.ellie_commons.tomato.json to 3.0.1

### DIFF
--- a/applications/io.github.ellie_commons.tomato.json
+++ b/applications/io.github.ellie_commons.tomato.json
@@ -1,5 +1,5 @@
 {
     "source": "https://github.com/ellie-commons/tomato.git",
-    "commit": "c9183b5a5c09917f6dbbe15522ae8abd3a60b99d",
-    "version": "3.0.0"
+    "commit": "61dde94c3251b1c7104b1aec40332ca5e8358614",
+    "version": "3.0.1"
 }


### PR DESCRIPTION
Comparison: https://github.com/ellie-commons/tomato/compare/c9183b5a5c09917f6dbbe15522ae8abd3a60b99d..61dde94c3251b1c7104b1aec40332ca5e8358614

@alainm23 Can you confirm you're happy to release these changes as `3.0.1`? We had some issues with the `3.0` version not being valid [SemVer](https://semver.org/) (i.e. it should have been `3.0.0`), so I prepared a new release with the current changes, let me know if that's okay!

<!-- appcenter-review-checklist -->

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable