### PR TITLE
com.github.ryonakano.louper 2.0.6

### DIFF
--- a/applications/com.github.ryonakano.louper.json
+++ b/applications/com.github.ryonakano.louper.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ryonakano/louper.git",
-  "commit": "29632095996ce8f88e3b843c634a98bcb5636b1f",
-  "version": "2.0.5"
+  "commit": "93dbf926e4caba213f209ea189885da4e66f4146",
+  "version": "2.0.6"
 }


### PR DESCRIPTION
- Diff from the previous release: https://github.com/ryonakano/louper/compare/2.0.5..2.0.6
- Release note: https://github.com/ryonakano/louper/releases/tag/2.0.6
