### PR TITLE
Update jorts to 3.1.3

### DIFF
--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "f5c99a9637855d98b7ef714eb08b1f9b6aca9987",
-  "version": "3.1.1"
+  "commit": "f22fdd9beae0d313e80330b1e4272d8eecf657ae",
+  "version": "3.1.2"
 }

--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "649e0a12dadecd136aaa9f9d7d0c29472cdb8538",
-  "version": "2.4.1"
+  "commit": "922730da20db631e8541976a094280967507b344",
+  "version": "2.4.2"
 }

--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "f22fdd9beae0d313e80330b1e4272d8eecf657ae",
-  "version": "3.1.2"
+  "commit": "e9faef15317ee4dbb81eba6871ad5f1e4b72fe67",
+  "version": "3.1.3"
 }

--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "5b22681c7cc102c7a528f9adbf57bcd7a0d8a8ae",
-  "version": "3.1.0"
+  "commit": "f5c99a9637855d98b7ef714eb08b1f9b6aca9987",
+  "version": "3.1.1"
 }

--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "f7dbb1c56b4a9ec8874e91cf3cc180920ac8e77e",
-  "version": "2.4.0"
+  "commit": "649e0a12dadecd136aaa9f9d7d0c29472cdb8538",
+  "version": "2.4.1"
 }

--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "7d6f0077e64a652c3e1b597648cdba6ae1ffcdae",
-  "version": "3.0.0"
+  "commit": "5b22681c7cc102c7a528f9adbf57bcd7a0d8a8ae",
+  "version": "3.1.0"
 }

--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "f1612e38b139cd3760d4383bb940f9097c09b9a4",
-  "version": "2.3.0"
+  "commit": "f7dbb1c56b4a9ec8874e91cf3cc180920ac8e77e",
+  "version": "2.4.0"
 }

--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "922730da20db631e8541976a094280967507b344",
-  "version": "2.4.2"
+  "commit": "7d6f0077e64a652c3e1b597648cdba6ae1ffcdae",
+  "version": "3.0.0"
 }


### PR DESCRIPTION

I wanted to release this once i got a flathub port and a windows port

However im stalled on the flathub port by some weird flatpak-builder issues i cant figure out
and the windows port is... i need time to do a VM, setup MSYS, setup everything, and my attention is elsewhere atm

so theyll have to wait. I want people to have @wpkelso's lovely new icon without waiting for months

<!-- appcenter-review-checklist -->

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable