### PR TITLE
Update jorts to 3.2.2

### DIFF
--- a/applications/io.github.ellie_commons.jorts.json
+++ b/applications/io.github.ellie_commons.jorts.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/Jorts.git",
-  "commit": "a32aef8317889ae7cb979c5393aaf5245fd2878e",
-  "version": "3.2.1"
+  "commit": "72af4ffa4747218ec83eaf215b62a7e3075f4ecb",
+  "version": "3.2.2"
 }


### PR DESCRIPTION
A quick bugfix for a bit of an irksome bug
in the process i discovered the actionbar has a builtin revealer

<!-- appcenter-review-checklist -->

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable