### PR TITLE
Create io.github.stsdc.gadget_clock.json

### DIFF
--- a/applications/io.github.stsdc.gadget_clock.json
+++ b/applications/io.github.stsdc.gadget_clock.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/stsdc/gadget_clock.git",
-  "commit": "1b6eb31c077ddd1f5ab59e9122cda34909ce3848",
-  "version": "0.5.0"
+  "commit": "90d4b3ecd2b8bba9eebb40777eaf2ba908d7b197",
+  "version": "0.5.1"
 }

--- a/applications/io.github.stsdc.gadget_clock.json
+++ b/applications/io.github.stsdc.gadget_clock.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/stsdc/gadget_clock.git",
+  "commit": "2eb072bd0685319a82d90b9a293399810548107b",
+  "version": "0.4.0"
+}

--- a/applications/io.github.stsdc.gadget_clock.json
+++ b/applications/io.github.stsdc.gadget_clock.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/stsdc/gadget_clock.git",
-  "commit": "2eb072bd0685319a82d90b9a293399810548107b",
-  "version": "0.4.0"
+  "commit": "1b6eb31c077ddd1f5ab59e9122cda34909ce3848",
+  "version": "0.5.0"
 }


### PR DESCRIPTION
This is a continuation of #580.
The `GdkPixbuf` deprecation will be removed in the next version.

<!-- appcenter-review-checklist -->

## Review Checklist

- [x] App opens
- [x] Does what it says
- [x] Categories match

### AppData
- [x] Name is unique and non-confusing
- [x] Matches description
- [x] Matches screenshot
- [x] Launchable tag with matching ID
- [x] Release tag with matching version and YYYY-MM-DD date
- [x] OARS info matches

### Flatpak
- [x] Uses elementary runtime
- [x] Sandbox permissions are reasonable