### PR TITLE
Update Reminduck (it has been so long!)

### DIFF
--- a/applications/com.github.matfantinel.reminduck.json
+++ b/applications/com.github.matfantinel.reminduck.json
@@ -1,5 +1,7 @@
 {
   "source": "https://github.com/matfantinel/reminduck.git",
   "commit": "b66efd6657ed74da38be5ba94a8e3ef51f651989",
-  "version": "1.6.2"
+  "version": "1.6.2",
+  "end-of-life": "Updated by the ellie-commons initiative",
+  "end-of-life-rebase": "io.github.ellie_commons.reminduck"
 }

--- a/applications/com.github.matfantinel.reminduck.json
+++ b/applications/com.github.matfantinel.reminduck.json
@@ -1,7 +1,5 @@
 {
   "source": "https://github.com/matfantinel/reminduck.git",
   "commit": "b66efd6657ed74da38be5ba94a8e3ef51f651989",
-  "version": "1.6.2",
-  "end-of-life": "Updated by the ellie-commons initiative",
-  "end-of-life-rebase": "io.github.ellie_commons.reminduck"
+  "version": "1.6.2"
 }

--- a/applications/io.github.ellie_commons.reminduck.json
+++ b/applications/io.github.ellie_commons.reminduck.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/reminduck.git",
-  "commit": "",
+  "commit": "44202513df5e7e4b82b57d205961ad407e25840c",
   "version": "2.0.0"
 }

--- a/applications/io.github.ellie_commons.reminduck.json
+++ b/applications/io.github.ellie_commons.reminduck.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/reminduck.git",
-  "commit": "44202513df5e7e4b82b57d205961ad407e25840c",
-  "version": "2.0.0"
+  "commit": "573e0a3d602fed77024a1384b667577ca6ac6ef7",
+  "version": "2.0.1"
 }

--- a/applications/io.github.ellie_commons.reminduck.json
+++ b/applications/io.github.ellie_commons.reminduck.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/ellie-commons/reminduck.git",
+  "commit": "",
+  "version": "2.0.0"
+}


### PR DESCRIPTION
A new version, with modern port, of Reminduck

This is not just a fork of [the old unmaintained one](https://github.com/elementary/appcenter-reviews/blob/main/applications/com.github.matfantinel.reminduck.json), but its continuation transferred from Matt (i can share the email exchange)

would the old one need to be deleted? there risks to be confusion.
or would it work to softlink the old one to this one?

<!-- appcenter-review-checklist -->

## Review Checklist

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable