### PR TITLE
Deprecate com.github.phoneybadger.picker.json

### DIFF
--- a/applications/com.github.phoneybadger.picker.json
+++ b/applications/com.github.phoneybadger.picker.json
@@ -1,5 +1,7 @@
 {
   "source": "https://github.com/phoneybadger/picker.git",
   "commit": "7f244e145529b696ea06b1461a050fde93477e2f",
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "end-of-life": "Updated by the ellie-commons initiative",
+  "end-of-life-rebase": "io.github.ellie_commons.cherrypick"
 }


### PR DESCRIPTION
phoneybadger.picker redirects to ellie_commons.cherrypick
https://github.com/phoneybadger/picker


<!-- appcenter-review-checklist -->

## Review Checklist
This checklist is used by reviewers, so you don't need to fill in by yourself.

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable