### PR TITLE
Update Cherrypick to 2.1.0

### DIFF
--- a/applications/io.github.ellie_commons.cherrypick.json
+++ b/applications/io.github.ellie_commons.cherrypick.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/cherrypick.git",
-  "commit": "f90ac45ca2ed07eb48939269da5332308635e94c",
-  "version": "2.0.1"
+  "commit": "33cb31facb513fd0ab28786d0e1da9d0724287d9",
+  "version": "2.1.0"
 }


### PR DESCRIPTION
Ryo's nitpick on a missing space made me look for an opportunity for a new release, because it is the kind of detail you cant unsee

Their PR kicked me into taking care of a deprecated widget and doing finally a release with all the polish. If Cherrypick ends up unmaintained at least it can hold a solid while now

(and now i realize i left it at 8 instead of 8.2... Hope theres not too much missing out)

<!-- appcenter-review-checklist -->

## Review Checklist
This checklist is used by reviewers, so you don't need to fill in by yourself.

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable