### PR TITLE
Update cherrypick to 2.1.2

### DIFF
--- a/applications/io.github.ellie_commons.cherrypick.json
+++ b/applications/io.github.ellie_commons.cherrypick.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ellie-commons/cherrypick.git",
-  "commit": "33cb31facb513fd0ab28786d0e1da9d0724287d9",
-  "version": "2.1.0"
+  "commit": "71c5ed2faf1c3bf9a3ddaa451104ef1b02f511cd",
+  "version": "2.1.2"
 }


### PR DESCRIPTION
One simple bugfix where the desktop action did not work if the app was already open