### PR TITLE
Bump Comic Sticks to version 1.7.3.

### DIFF
--- a/applications/com.github.rkoesters.xkcd-gtk.json
+++ b/applications/com.github.rkoesters.xkcd-gtk.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/rkoesters/xkcd-gtk.git",
-  "commit": "8aa7c28e13c0383ebf6b9d4b28d501cdc47f3e34",
-  "version": "v1.7.2"
+  "commit": "885489f1b67a5e1d8e5361e35440adfbd0177c79",
+  "version": "v1.7.3"
 }


### PR DESCRIPTION
https://github.com/rkoesters/xkcd-gtk/releases/tag/v1.7.3

<!-- appcenter-review-checklist -->

## Review Checklist
This checklist is used by reviewers, so you don't need to fill in by yourself.

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable