### PR TITLE
Update Haguichi to 1.154.0

### DIFF
--- a/applications/com.github.ztefn.haguichi.json
+++ b/applications/com.github.ztefn.haguichi.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ztefn/haguichi.git",
-  "commit": "f0ae89ddd5981be047913348c590c5634e6a2acb",
-  "version": "1.153.0"
+  "commit": "2f382933181ade7946e1e8c8f7c09f99b6f6caa1",
+  "version": "1.154.0"
 }

--- a/applications/com.github.ztefn.haguichi.json
+++ b/applications/com.github.ztefn.haguichi.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/ztefn/haguichi.git",
-  "commit": "2f382933181ade7946e1e8c8f7c09f99b6f6caa1",
+  "commit": "663d9797b518f5f3efae403e55b45cccba2f57d7",
   "version": "1.154.0"
 }


### PR DESCRIPTION
Rebased [elementary](https://github.com/ztefn/haguichi/tree/elementary) branch on top of [master](https://github.com/ztefn/haguichi/tree/master) again from commit [d498e2e to 2f38293](https://github.com/ztefn/haguichi/compare/d498e2e...2f38293).

Release tag: [1.154.0](https://github.com/ztefn/haguichi/releases/tag/1.154.0)

<!-- appcenter-review-checklist -->

## Review Checklist
This checklist is used by reviewers, so you don't need to fill in by yourself.

- [ ] App opens
- [ ] Does what it says
- [ ] Categories match

### AppData
- [ ] Name is unique and non-confusing
- [ ] Matches description
- [ ] Matches screenshot
- [ ] Launchable tag with matching ID
- [ ] Release tag with matching version and YYYY-MM-DD date
- [ ] OARS info matches

### Flatpak
- [ ] Uses elementary runtime
- [ ] Sandbox permissions are reasonable