### PR TITLE
publish: Back to flatpak-platform Docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,40 +41,18 @@ jobs:
     strategy:
       matrix:
         configuration:
-          # FIXME: Remove flat-manager-suffix when we update to the container with flatpak-builder >= 1.4.6
           - arch: x86_64
             runs-on: ubuntu-latest
-            flat-manager-suffix: amd64
-            flat-manager-sha256: 9733a148ac185bc8d7fb0429a43f9ad7d934635760bb71933658642c697f87c9
           - arch: aarch64
             runs-on: ubuntu-24.04-arm
-            flat-manager-suffix: arm64
-            flat-manager-sha256: fa9a916badc539ff7319895789f004dc99b81eb8e90a75857232121650335956
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
 
     container:
-      # mirror-screenshots-url option of flatpak-builder action requires flatpak-builder >= 1.4.6,
-      # which is only available on questing or later, to use --compose-url-policy option internally
-      # FIXME: Replace with newer version of our platform that based on resolute
-      #image: ghcr.io/elementary/flatpak-platform/runtime:8-${{ matrix.configuration.arch }}
-      image: ubuntu:resolute
+      image: ghcr.io/elementary/flatpak-platform/runtime:8-${{ matrix.configuration.arch }}
       options: --privileged
 
     steps:
-      # FIXME: Remove when we update to the container with flatpak-builder >= 1.4.6
-      - name: Install dependencies
-        run: |
-          apt install -yU curl git flatpak-builder xvfb
-          curl -L https://github.com/flatpak/flat-manager/releases/download/0.5.0/flat-manager-client.${{ matrix.configuration.flat-manager-suffix }} -o ./flat-manager-client
-          SHA256_CALC=$(sha256sum ./flat-manager-client | awk '{ print $1 }')
-          if [ "$SHA256_CALC" != "${{ matrix.configuration.flat-manager-sha256 }}" ]; then
-            echo "flat-manager-client verify error! got $SHA256_CALC"
-            exit 1
-          fi
-          mv ./flat-manager-client /usr/bin/flat-manager-client
-          chmod +x /usr/bin/flat-manager-client
-
       - name: Checkout
         run: |
           git config --global --add safe.directory /__w/appcenter-reviews/appcenter-reviews


### PR DESCRIPTION
Fixes #644

Requires https://github.com/elementary/flatpak-platform/pull/234 merged first

## Checklist
- [x] Building Minder succeeds (it failed to deploy in the following screenshot because I didn't feed the API key)  
  <img width="1649" height="939" alt="スクリーンショット 2026-05-03 11 21 56" src="https://github.com/user-attachments/assets/28838da0-93f4-4a64-b8ac-07f693dffec3" />
- [x] .metainfo file of Minder after `appstreamcli compose` still has the `x-appcenter` keys  
  → See https://github.com/elementary/flatpak-platform/pull/234#issuecomment-4365502293